### PR TITLE
Add local Docker registry (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ doc/
 
 # Box storage for spec
 test/vagrant-spec/boxes/*.box
+*.retry

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "base"
-  config.vm.box_url = "file://builds/packer_virtualbox-iso_virtualbox.box"
+  config.vm.box_url = "file://boxes/packer_virtualbox-iso_virtualbox.box"
 
   config.vm.define "server" do |server|
     server.vm.hostname = "server"
@@ -21,7 +21,13 @@ Vagrant.configure("2") do |config|
   config.vm.define "client" do |client|
     client.vm.hostname = "client"
 
+    client.vm.network "forwarded_port", guest: 443, host: 5000
     client.vm.network "private_network", ip: "172.20.20.10"
+
+    client.vm.provision "ansible" do |ansible|
+      ansible.ask_become_pass = true
+      ansible.playbook = "certificate.yml"
+    end
 
     client.vm.provision "ansible_local" do |ansible|
       ansible.playbook = "playbook.yml"
@@ -33,4 +39,9 @@ end
 
 # All custom Vagrant configuration is done below.
 Vagrant.configure("2") do |config|
+  config.vm.define "server" do |server|
+  end
+
+  config.vm.define "client" do |client|
+  end
 end

--- a/builds/README.md
+++ b/builds/README.md
@@ -1,1 +1,0 @@
-This directory contains any Packer [Artifacts](https://www.packer.io/docs/basics/terminology.html#artifacts) created using Packer [Post-Processors](https://www.packer.io/docs/post-processors/index.html). It is intentionally empty.

--- a/certificate.yml
+++ b/certificate.yml
@@ -2,20 +2,25 @@
 
 - hosts: all
   connection: local
+  vars:
+    certificate: registry.service.consul
   tasks:
-  - name: Add self-signed certificate to trusted CAs
+  - name: Check if {{ certificate }} exists
     command: |
-      security add-trusted-cert \
-      -d \
-      -r trustRoot \
-      -k /Library/Keychains/System.keychain \
-      ansible.crt
+      security -q find-certificate -a -c {{ certificate }} -p /Library/Keychains/System.keychain
     become: yes
+    register: response
     when: ansible_os_family == "Darwin"
 
-  - name: Add registry.service.consul to hosts file
+  - name: Add self-signed certificate to trusted CAs
+    command: |
+      security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ansible.crt
+    become: yes
+    when: ansible_os_family == "Darwin" and response.stdout == ""
+
+  - name: Add {{ certificate }} to hosts file
     blockinfile:
-      block: 127.0.0.1 registry.service.consul
+      block: 127.0.0.1 {{ certificate }}
       path: /etc/hosts
       state: present
     become: yes

--- a/certificate.yml
+++ b/certificate.yml
@@ -1,0 +1,26 @@
+---
+
+- hosts: all
+  connection: local
+  tasks:
+  - name: Add self-signed certificate to trusted CAs
+    command: |
+      security add-trusted-cert \
+      -d \
+      -r trustRoot \
+      -k /Library/Keychains/System.keychain \
+      ansible.crt
+    become: yes
+    when: ansible_os_family == "Darwin"
+
+  - name: Add registry.service.consul to hosts file
+    blockinfile:
+      block: 127.0.0.1 registry.service.consul
+      path: /etc/hosts
+      state: present
+    become: yes
+
+  - name: Remove certificate from host OS
+    file:
+      path: ansible.crt
+      state: absent

--- a/ubuntu/16.04.3-server-amd64.json
+++ b/ubuntu/16.04.3-server-amd64.json
@@ -42,24 +42,11 @@
           "{{ user `memory` }}"
         ]
       ]
-    },
-    {
-      "host": "{{ user `vsphere_host` }}",
-      "insecure_connection": true,
-      "password": "{{ user `vsphere_password` }}",
-      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
-      "ssh_password": "{{ user `ssh_password` }}",
-      "ssh_username": "{{ user `ssh_username` }}",
-      "template": "{{ user `vsphere_template` }}",
-      "type": "vsphere",
-      "username": "{{ user `vsphere_username` }}",
-      "vcenter_server": "{{ user `vcenter_server` }}",
-      "vm_name": "{{ user `vm_name` }}"
     }
   ],
   "post-processors": [
     {
-      "output": "{{ template_dir }}/../builds/packer_{{ .BuildName }}_{{ .Provider }}.box",
+      "output": "{{ template_dir }}/../boxes/packer_{{ .BuildName }}_{{ .Provider }}.box",
       "type": "vagrant"
     }
   ],
@@ -84,6 +71,12 @@
       "playbook_file": "{{ template_dir }}/configuration/playbook.yml",
       "staging_directory": "/home/vagrant/packer-provisioner-ansible-local",
       "type": "ansible-local"
+    },
+    {
+      "destination": "{{ template_dir }}/../ansible.crt",
+      "direction": "download",
+      "source": "/usr/local/share/ca-certificates/ansible.crt",
+      "type": "file"
     }
   ],
   "variables": {
@@ -93,12 +86,6 @@
     "memory": "2048",
     "ssh_password": "vagrant",
     "ssh_username": "vagrant",
-    "ssh_wait_timeout": "10000s",
-    "vcenter_server": "",
-    "vm_name": "",
-    "vsphere_host": "",
-    "vsphere_password": "",
-    "vsphere_template": "",
-    "vsphere_username": ""
+    "ssh_wait_timeout": "10000s"
   }
 }

--- a/ubuntu/configuration/playbook.yml
+++ b/ubuntu/configuration/playbook.yml
@@ -5,6 +5,7 @@
   - common
   - firewall
   - docker
+  - cryptography
   - vagrant
   - consul
   - vault

--- a/ubuntu/configuration/roles/cryptography/tasks/main.yml
+++ b/ubuntu/configuration/roles/cryptography/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Copy custom openssl configuration file
+  template:
+    dest: /etc/ssl/ansible.cnf
+    src: openssl.cnf.j2
+  become: yes
+
+- name: Create new self-signed certificate using custom openssl configuration
+  command: |
+    openssl req \
+    -newkey rsa:4096 \
+    -nodes \
+    -sha256 \
+    -keyout /etc/ssl/private/ansible.key \
+    -x509 \
+    -days 365 \
+    -out /usr/local/share/ca-certificates/ansible.crt \
+    -config /etc/ssl/ansible.cnf
+  become: yes
+
+- name: Update CA certificates
+  command: update-ca-certificates
+  become: yes

--- a/ubuntu/configuration/roles/cryptography/templates/openssl.cnf.j2
+++ b/ubuntu/configuration/roles/cryptography/templates/openssl.cnf.j2
@@ -1,0 +1,20 @@
+[ req ]
+default_bits           = 4096
+distinguished_name     = req_distinguished_name
+prompt                 = no
+x509_extensions        = v3_req
+
+[ req_distinguished_name ]
+commonName             = {{ common_name }}
+countryName            = {{ country_name }}
+localityName           = {{ locality_name }}
+organizationName       = {{ organization_name }}
+organizationalUnitName = {{ organizational_unit_name }}
+stateOrProvinceName    = {{ state_or_province_name }}
+
+[ v3_req ]
+subjectAltName         = @alt_names
+
+[ alt_names ]
+DNS.0                  = {{ common_name }}
+IP.0                   = {{ ansible_enp0s3.ipv4.address }}

--- a/ubuntu/configuration/roles/cryptography/vars/main.yml
+++ b/ubuntu/configuration/roles/cryptography/vars/main.yml
@@ -1,0 +1,8 @@
+---
+
+common_name: registry.service.consul
+country_name: US
+locality_name: Philadelphia
+organization_name: Hospital of the University of Pennsylvania
+organizational_unit_name: Data Science
+state_or_province_name: Pennsylvania

--- a/ubuntu/configuration/roles/docker/files/daemon.json
+++ b/ubuntu/configuration/roles/docker/files/daemon.json
@@ -1,4 +1,7 @@
 {
+  "insecure-registries": [
+    "registry.service.consul:5000"
+  ],
   "log-driver": "syslog",
   "log-opts": {
     "syslog-address": "udp://0.0.0.0:1111"

--- a/ubuntu/configuration/roles/nomad/files/jobs/registry.nomad
+++ b/ubuntu/configuration/roles/nomad/files/jobs/registry.nomad
@@ -1,0 +1,129 @@
+{
+    "Job": {
+        "Stop": null,
+        "Region": null,
+        "Namespace": null,
+        "ID": "registry",
+        "ParentID": null,
+        "Name": "registry",
+        "Type": null,
+        "Priority": null,
+        "AllAtOnce": null,
+        "Datacenters": [
+            "dc1"
+        ],
+        "Constraints": null,
+        "TaskGroups": [
+            {
+                "Name": "registry",
+                "Count": null,
+                "Constraints": null,
+                "Tasks": [
+                    {
+                        "Name": "registry",
+                        "Driver": "docker",
+                        "User": "",
+                        "Config": {
+                            "image": "registry",
+                            "network_mode": "host",
+                            "port_map": [
+                                {
+                                    "registry": 443
+                                }
+                            ],
+                            "volumes": [
+                                "/etc/ssl/private:/etc/ssl/private:ro",
+                                "/usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro"
+                            ]
+                        },
+                        "Constraints": null,
+                        "Env": {
+                            "REGISTRY_HTTP_ADDR": "0.0.0.0:443",
+                            "REGISTRY_HTTP_TLS_CERTIFICATE": "/usr/local/share/ca-certificates/ansible.crt",
+                            "REGISTRY_HTTP_TLS_KEY": "/etc/ssl/private/ansible.key"
+                        },
+                        "Services": [
+                            {
+                                "Id": "",
+                                "Name": "registry",
+                                "Tags": null,
+                                "PortLabel": "registry",
+                                "AddressMode": "",
+                                "Checks": [
+                                    {
+                                        "Id": "",
+                                        "Name": "",
+                                        "Type": "http",
+                                        "Command": "",
+                                        "Args": null,
+                                        "Path": "/v2/",
+                                        "Protocol": "https",
+                                        "PortLabel": "",
+                                        "AddressMode": "",
+                                        "Interval": 10000000000,
+                                        "Timeout": 30000000000,
+                                        "InitialStatus": "",
+                                        "TLSSkipVerify": false,
+                                        "Header": null,
+                                        "Method": "",
+                                        "CheckRestart": null
+                                    }
+                                ],
+                                "CheckRestart": null
+                            }
+                        ],
+                        "Resources": {
+                            "CPU": null,
+                            "MemoryMB": null,
+                            "DiskMB": null,
+                            "IOPS": null,
+                            "Networks": [
+                                {
+                                    "Device": "",
+                                    "CIDR": "",
+                                    "IP": "",
+                                    "MBits": null,
+                                    "ReservedPorts": [
+                                        {
+                                            "Label": "registry",
+                                            "Value": 443
+                                        }
+                                    ],
+                                    "DynamicPorts": null
+                                }
+                            ]
+                        },
+                        "Meta": null,
+                        "KillTimeout": null,
+                        "LogConfig": null,
+                        "Artifacts": null,
+                        "Vault": null,
+                        "Templates": null,
+                        "DispatchPayload": null,
+                        "Leader": false,
+                        "ShutdownDelay": 0,
+                        "KillSignal": ""
+                    }
+                ],
+                "RestartPolicy": null,
+                "EphemeralDisk": null,
+                "Update": null,
+                "Meta": null
+            }
+        ],
+        "Update": null,
+        "Periodic": null,
+        "ParameterizedJob": null,
+        "Payload": null,
+        "Meta": null,
+        "VaultToken": "myroot",
+        "Status": null,
+        "StatusDescription": null,
+        "Stable": null,
+        "Version": null,
+        "SubmitTime": null,
+        "CreateIndex": null,
+        "ModifyIndex": null,
+        "JobModifyIndex": null
+    }
+}

--- a/ubuntu/configuration/roles/nomad/tasks/jobs.yml
+++ b/ubuntu/configuration/roles/nomad/tasks/jobs.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Create shared nomad jobs directory
+  file:
+    group: nomad
+    owner: nomad
+    path: /usr/local/share/nomad
+    recurse: yes
+    state: directory
+  become: yes
+
+- name: Copy nomad job files to remote host
+  copy:
+    dest: /usr/local/share/nomad
+    group: nomad
+    owner: nomad
+    src: jobs
+  become: yes
+
+- name: Schedule nomad jobs
+  uri:
+    body: "{{ lookup('file', item) }}"
+    body_format: json
+    method: POST
+    url: http://nomad.service.consul:4646/v1/jobs
+  with_fileglob:
+  - /usr/local/share/nomad/jobs/*

--- a/ubuntu/configuration/roles/nomad/tasks/main.yml
+++ b/ubuntu/configuration/roles/nomad/tasks/main.yml
@@ -84,3 +84,7 @@
   become: yes
   tags:
   - bootstrap
+
+- include_tasks: jobs.yml
+  tags:
+  - client


### PR DESCRIPTION
## Update

The `ansible.crt` file is automatically added to the trusted certificates.

**Verification steps:**

    $ packer build -only=virtualbox-iso 16.04.3-server-amd64.json
    $ cd .. && vagrant up

## Do not follow the instructions defined below

After successfully building the image and virtual machine(s), copy the self-signed certificate to the shared partition (`/vagrant`) and add it to Keychain Access.

    $ vagrant ssh client
    $ sudo cp /usr/local/share/ca-certificates/ansible.crt /vagrant
    $ exit

Drag the `ansible.crt` file into the `login` keychain under the `Certificates` category:

<img width="989" alt="screen shot 2018-02-07 at 2 53 16 pm" src="https://user-images.githubusercontent.com/2184329/35938347-c94c82ba-0c16-11e8-87b1-6a5e198e94fc.png">

After the certificate is imported, right click the `registry.service.consul` certificate and click **Get Info**. Click on **Trust** and then select **Always Trust** from the **When using this certificate:** dropdown:

![screen shot 2018-02-07 at 2 55 37 pm](https://user-images.githubusercontent.com/2184329/35938491-3bcf831e-0c17-11e8-9450-4ef692ce1d0a.png)

Finally, run the following command:

    $ echo '127.0.0.1 registry.service.consul' | sudo tee -a /etc/hosts > /dev/null

Unfortunately, this is a lengthy process, however, there are plans to automate it.

Closes #3
Closes #5